### PR TITLE
Improve remote responsiveness and caching

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -152,6 +152,40 @@ main {
   margin-bottom: 18px;
 }
 
+.loading-strip {
+  position: relative;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(123, 156, 255, 0.18);
+  overflow: hidden;
+  margin: 10px 0 16px;
+}
+
+.loading-strip__bar {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    rgba(151, 189, 255, 0.95) 45%,
+    rgba(123, 156, 255, 0.6) 55%,
+    transparent 100%
+  );
+  animation: loading-strip-slide 1.1s ease-in-out infinite;
+}
+
+@keyframes loading-strip-slide {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 .tabs-left {
   display: flex;
   gap: 10px;


### PR DESCRIPTION
## Summary
- add profile-aware cache helpers and preserve remote window state while loading new sessions
- show a loading strip and status text while switching modes for better feedback
- harden session rename flow to refresh state optimistically and eliminate false failures
- cover new cache helpers with unit tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e39a4be4b88322b1fcea6e68d5c5e6