### PR TITLE
Improve remote key handling and compact settings

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -212,35 +212,68 @@ main {
 
 .loading-strip {
   position: relative;
-  height: 3px;
+  height: 4px;
   border-radius: 999px;
-  background: rgba(123, 156, 255, 0.18);
+  background: linear-gradient(90deg, rgba(123, 156, 255, 0.18), rgba(151, 189, 255, 0.08));
   overflow: hidden;
-  margin: 6px 0 12px;
+  margin: 8px 0 14px;
+  box-shadow: inset 0 0 0 1px rgba(123, 156, 255, 0.12);
 }
 
 .loading-strip__bar {
   position: absolute;
   inset: 0;
-  background: linear-gradient(
-    90deg,
-    rgba(123, 156, 255, 0) 0%,
-    rgba(151, 189, 255, 0.7) 25%,
-    rgba(123, 156, 255, 0.95) 50%,
-    rgba(151, 189, 255, 0.7) 75%,
-    rgba(123, 156, 255, 0) 100%
-  );
-  background-size: 200% 100%;
-  animation: loading-strip-slide 0.75s linear infinite;
-  will-change: background-position;
+  background: linear-gradient(90deg, transparent, rgba(176, 205, 255, 0.85), rgba(123, 156, 255, 0.2), transparent);
+  width: 140%;
+  transform: translateX(-60%);
+  animation: loading-strip-flow 1.3s ease-in-out infinite;
+  will-change: transform;
 }
 
-@keyframes loading-strip-slide {
+.loading-strip__pulse {
+  position: absolute;
+  top: -8px;
+  bottom: -8px;
+  width: 22%;
+  background: radial-gradient(circle at center, rgba(191, 214, 255, 0.9) 0%, rgba(123, 156, 255, 0) 70%);
+  opacity: 0.85;
+  filter: blur(4px);
+  transform: translateX(-40%);
+  animation: loading-strip-pulse 1.8s ease-in-out infinite;
+  pointer-events: none;
+}
+
+@keyframes loading-strip-flow {
   0% {
-    background-position: 200% 0;
+    transform: translateX(-60%);
+  }
+  50% {
+    transform: translateX(35%);
   }
   100% {
-    background-position: -200% 0;
+    transform: translateX(130%);
+  }
+}
+
+@keyframes loading-strip-pulse {
+  0% {
+    transform: translateX(-50%);
+    opacity: 0.45;
+  }
+  50% {
+    transform: translateX(40%);
+    opacity: 1;
+  }
+  100% {
+    transform: translateX(120%);
+    opacity: 0.45;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-strip__bar,
+  .loading-strip__pulse {
+    animation-duration: 3.2s;
   }
 }
 
@@ -458,4 +491,156 @@ form input[name="cmd"] {
 
 .settings-actions .spacer {
   flex: 1 1 auto;
+}
+
+.settings-panel {
+  display: grid;
+  gap: 12px;
+  max-width: 780px;
+  font-size: 13px;
+  line-height: 1.45;
+}
+
+.settings-panel__title {
+  margin: 0 0 4px;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.settings-panel__back {
+  justify-self: flex-start;
+  font-size: 12.5px;
+  padding: 5px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(123, 156, 255, 0.25);
+  background: rgba(12, 16, 27, 0.65);
+  color: var(--text);
+  cursor: pointer;
+}
+
+.settings-panel__back:hover {
+  background: rgba(123, 156, 255, 0.18);
+}
+
+.settings-panel__error {
+  color: #ff6b6b;
+  font-size: 13px;
+}
+
+.settings-panel button {
+  background: rgba(123, 156, 255, 0.18);
+  border: 1px solid rgba(123, 156, 255, 0.28);
+  color: var(--text);
+  padding: 6px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.18s ease;
+}
+
+.settings-panel button:hover {
+  background: rgba(123, 156, 255, 0.28);
+  transform: translateY(-1px);
+}
+
+.settings-panel input,
+.settings-panel select {
+  background: rgba(12, 16, 27, 0.82);
+  border: 1px solid rgba(123, 156, 255, 0.22);
+  color: var(--text);
+  padding: 7px 10px;
+  border-radius: 10px;
+  font-size: 13px;
+  min-height: 32px;
+}
+
+.settings-panel input:focus-visible {
+  outline: none;
+  border-color: rgba(151, 189, 255, 0.7);
+  box-shadow: 0 0 0 2px rgba(123, 156, 255, 0.22);
+}
+
+.settings-field {
+  display: grid;
+  gap: 4px;
+}
+
+.settings-field__row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.settings-field--compact input {
+  max-width: 140px;
+}
+
+.settings-field--span-2 {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 560px) {
+  .settings-field--span-2 {
+    grid-column: auto;
+  }
+}
+
+.settings-hint {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.settings-status {
+  font-size: 12px;
+  opacity: 0.78;
+  min-height: 16px;
+}
+
+.settings-panel__remote {
+  display: grid;
+  gap: 12px;
+  padding-top: 8px;
+}
+
+.settings-panel__remote-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.settings-panel__remote-header h3 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.settings-panel__remote-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.settings-panel__remote-grid {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+}
+
+.settings-panel__auth {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+  align-items: center;
+}
+
+.settings-panel__auth label {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
 }

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -130,174 +130,246 @@ export default function Settings({ onSwitchToRuns }: SettingsProps) {
   }
 
   return (
-    <div style={{ display: "grid", gap: 16, maxWidth: 760 }}>
-      <h2>Settings</h2>
+    <div className="settings-panel">
+      <h2 className="settings-panel__title">Settings</h2>
       {onSwitchToRuns && (
-        <button onClick={onSwitchToRuns} style={{ justifySelf: "start" }}>
+        <button onClick={onSwitchToRuns} className="settings-panel__back" type="button">
           ← Back to Runs
         </button>
       )}
-      {err && <div style={{ color: "#ff6b6b" }}>{err}</div>}
+      {err && <div className="settings-panel__error">{err}</div>}
 
       {/* Python */}
-      <label style={{ display: "grid", gap: 6 }}>
+      <label className="settings-field">
         <span>Python path</span>
-        <div style={{ display: "flex", gap: 8 }}>
-          <input style={{ flex: 1 }} value={cfg.python_path}
-                 onChange={(e) => up({ python_path: e.target.value })}
-                 placeholder="/home/calvin/miniforge3/envs/arc_env/bin/python" />
-          <button onClick={async () => {
-            const p = await openDialog({ multiple: false }); if (p) up({ python_path: p as string });
-          }}>Browse…</button>
+        <div className="settings-field__row">
+          <input
+            value={cfg.python_path}
+            onChange={(e) => up({ python_path: e.target.value })}
+            placeholder="/home/calvin/miniforge3/envs/arc_env/bin/python"
+          />
+          <button
+            type="button"
+            onClick={async () => {
+              const p = await openDialog({ multiple: false });
+              if (p) up({ python_path: p as string });
+            }}
+          >
+            Browse…
+          </button>
         </div>
       </label>
 
       {/* ARC.py */}
-      <label style={{ display: "grid", gap: 6 }}>
+      <label className="settings-field">
         <span>ARC.py path</span>
-        <div style={{ display: "flex", gap: 8 }}>
-          <input style={{ flex: 1 }} value={cfg.arc_path}
-                 onChange={(e) => up({ arc_path: e.target.value })}
-                 placeholder="/home/calvin/Code/ARC/ARC.py" />
-          <button onClick={async () => {
-            const p = await openDialog({ multiple: false }); if (p) up({ arc_path: p as string });
-          }}>Browse…</button>
+        <div className="settings-field__row">
+          <input
+            value={cfg.arc_path}
+            onChange={(e) => up({ arc_path: e.target.value })}
+            placeholder="/home/calvin/Code/ARC/ARC.py"
+          />
+          <button
+            type="button"
+            onClick={async () => {
+              const p = await openDialog({ multiple: false });
+              if (p) up({ arc_path: p as string });
+            }}
+          >
+            Browse…
+          </button>
         </div>
       </label>
 
       {/* Work dir */}
-      <label style={{ display: "grid", gap: 6 }}>
+      <label className="settings-field">
         <span>Cluster work dir</span>
-        <input value={cfg.default_work_dir}
-               onChange={(e) => up({ default_work_dir: e.target.value })}
-               placeholder="/home/calvin.p/runs/ARC/PhD/RMG" />
+        <input
+          value={cfg.default_work_dir}
+          onChange={(e) => up({ default_work_dir: e.target.value })}
+          placeholder="/home/calvin.p/runs/ARC/PhD/RMG"
+        />
       </label>
 
       {/* Concurrency */}
-      <label style={{ display: "grid", gap: 6 }}>
+      <label className="settings-field settings-field--compact">
         <span>Concurrency cap</span>
-        <input type="number" min={1} max={64}
-               value={cfg.concurrency_cap}
-               onChange={(e) => up({ concurrency_cap: Number(e.target.value) || 1 })} />
+        <input
+          type="number"
+          min={1}
+          max={64}
+          value={cfg.concurrency_cap}
+          onChange={(e) => up({ concurrency_cap: Number(e.target.value) || 1 })}
+        />
       </label>
 
       {/* tmux path */}
-      <label style={{ display: "grid", gap: 6 }}>
+      <label className="settings-field">
         <span>tmux path (optional)</span>
-        <div style={{ display: "flex", gap: 8 }}>
-          <input style={{ flex: 1 }} value={cfg.tmux_path ?? ""}
-                 onChange={(e) => up({ tmux_path: e.target.value })}
-                 placeholder="Leave blank to use tmux from PATH" />
-          <button onClick={async () => {
-            const p = await openDialog({ multiple: false }); if (p) up({ tmux_path: p as string });
-          }}>Browse…</button>
+        <div className="settings-field__row">
+          <input
+            value={cfg.tmux_path ?? ""}
+            onChange={(e) => up({ tmux_path: e.target.value })}
+            placeholder="Leave blank to use tmux from PATH"
+          />
+          <button
+            type="button"
+            onClick={async () => {
+              const p = await openDialog({ multiple: false });
+              if (p) up({ tmux_path: p as string });
+            }}
+          >
+            Browse…
+          </button>
         </div>
-        <div style={{ fontSize: 12, opacity: 0.8 }}>
+        <div className="settings-hint">
           Don’t have tmux?{" "}
-          <a href="#" onClick={(e) => { e.preventDefault(); openUrl("https://github.com/tmux/tmux/wiki/Installing"); }}>
+          <a
+            href="#"
+            onClick={(e) => {
+              e.preventDefault();
+              openUrl("https://github.com/tmux/tmux/wiki/Installing");
+            }}
+          >
             Installation guide
           </a>
         </div>
       </label>
 
       {/* File ops */}
-      <div style={{ display: "flex", gap: 10, alignItems: "center", flexWrap: "wrap", paddingTop: 6 }}>
-        <button onClick={onSave}>Save</button>
-        <button onClick={onSaveAs}>Save As…</button>
-        <button onClick={onOpenFromFile}>Open…</button>
-        <span style={{ opacity: 0.8 }}>{status}</span>
-        {settingsPath && <code style={{ opacity: 0.7, fontSize: 12 }}>{settingsPath}</code>}
+      <div className="settings-actions">
+        <button type="button" onClick={onSave}>Save</button>
+        <button type="button" onClick={onSaveAs}>Save As…</button>
+        <button type="button" onClick={onOpenFromFile}>Open…</button>
+        <span className="settings-status">{status}</span>
+        <span className="spacer" />
+        {settingsPath && <code className="path">{settingsPath}</code>}
       </div>
 
       {/* Remote (SSH) */}
-      <section style={{ display: "grid", gap: 12, paddingTop: 12 }}>
-        <h3>Remote server (SSH)</h3>
+      <section className="settings-panel__remote">
+        <div className="settings-panel__remote-header">
+          <h3>Remote server (SSH)</h3>
+          <div className="settings-panel__remote-actions">
+            <button type="button" onClick={testRemote}>Log in</button>
+            <span className="settings-status">{status}</span>
+          </div>
+        </div>
 
-        <label style={{ display: "grid", gap: 6 }}>
-          <span>Host</span>
-          <input placeholder="hpc.example.edu"
-                 value={cfg.remote?.host ?? ""}
-                 onChange={(e) => upRemote({ host: e.target.value })} />
-        </label>
-
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
-          <label style={{ display: "grid", gap: 6 }}>
-            <span>Port</span>
-            <input type="number" min={1} max={65535}
-                   value={cfg.remote?.port ?? 22}
-                   onChange={(e) => upRemote({ port: Number(e.target.value) || 22 })} />
+        <div className="settings-panel__remote-grid">
+          <label className="settings-field settings-field--span-2">
+            <span>Host</span>
+            <input
+              placeholder="hpc.example.edu"
+              value={cfg.remote?.host ?? ""}
+              onChange={(e) => upRemote({ host: e.target.value })}
+            />
           </label>
-          <label style={{ display: "grid", gap: 6 }}>
+
+          <label className="settings-field">
+            <span>Port</span>
+            <input
+              type="number"
+              min={1}
+              max={65535}
+              value={cfg.remote?.port ?? 22}
+              onChange={(e) => upRemote({ port: Number(e.target.value) || 22 })}
+            />
+          </label>
+
+          <label className="settings-field">
             <span>User</span>
-            <input placeholder="calvin"
-                   value={cfg.remote?.user ?? ""}
-                   onChange={(e) => upRemote({ user: e.target.value })} />
+            <input
+              placeholder="calvin"
+              value={cfg.remote?.user ?? ""}
+              onChange={(e) => upRemote({ user: e.target.value })}
+            />
           </label>
         </div>
 
-        <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "center" }}>
-          <label><input type="radio" name="rauth"
-                        checked={(cfg.remote?.auth ?? "agent") === "agent"}
-                        onChange={() => upRemote({ auth: "agent", use_agent: true })} /> SSH agent</label>
-          <label><input type="radio" name="rauth"
-                        checked={cfg.remote?.auth === "key"}
-                        onChange={() => upRemote({ auth: "key", use_agent: false })} /> Key file</label>
-          <label><input type="radio" name="rauth"
-                        checked={cfg.remote?.auth === "password"}
-                        onChange={() => upRemote({ auth: "password", use_agent: false })} /> Password</label>
+        <div className="settings-panel__auth">
+          <label>
+            <input
+              type="radio"
+              name="rauth"
+              checked={(cfg.remote?.auth ?? "agent") === "agent"}
+              onChange={() => upRemote({ auth: "agent", use_agent: true })}
+            />
+            <span>SSH agent</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="rauth"
+              checked={cfg.remote?.auth === "key"}
+              onChange={() => upRemote({ auth: "key", use_agent: false })}
+            />
+            <span>Key file</span>
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="rauth"
+              checked={cfg.remote?.auth === "password"}
+              onChange={() => upRemote({ auth: "password", use_agent: false })}
+            />
+            <span>Password</span>
+          </label>
         </div>
 
         {cfg.remote?.auth === "key" && (
-          <div style={{ display: "grid", gap: 12 }}>
-            <label style={{ display: "grid", gap: 6 }}>
+          <div className="settings-panel__remote-grid">
+            <label className="settings-field settings-field--span-2">
               <span>Private key path</span>
-              <div style={{ display: "flex", gap: 8 }}>
-                <input style={{ flex: 1 }} placeholder="~/.ssh/id_ed25519"
-                       value={cfg.remote?.key_path ?? ""}
-                       onChange={(e) => upRemote({ key_path: e.target.value })} />
-                <button onClick={async () => {
-                  const p = await openDialog({ multiple: false });
-                  if (p) upRemote({ key_path: p as string });
-                }}>Browse…</button>
+              <div className="settings-field__row">
+                <input
+                  placeholder="~/.ssh/id_ed25519"
+                  value={cfg.remote?.key_path ?? ""}
+                  onChange={(e) => upRemote({ key_path: e.target.value })}
+                />
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const p = await openDialog({ multiple: false });
+                    if (p) upRemote({ key_path: p as string });
+                  }}
+                >
+                  Browse…
+                </button>
               </div>
             </label>
-            <label style={{ display: "grid", gap: 6 }}>
+            <label className="settings-field">
               <span>Key passphrase (optional)</span>
-              <input type="password"
-                     value={cfg.remote?.key_pass ?? ""}
-                     onChange={(e) => upRemote({ key_pass: e.target.value })} />
+              <input
+                type="password"
+                value={cfg.remote?.key_pass ?? ""}
+                onChange={(e) => upRemote({ key_pass: e.target.value })}
+              />
             </label>
           </div>
         )}
 
         {cfg.remote?.auth === "password" && (
-          <label style={{ display: "grid", gap: 6 }}>
+          <label className="settings-field">
             <span>Password</span>
-            <div style={{ display: "flex", gap: 8 }}>
+            <div className="settings-field__row">
               <input
                 type={showPw ? "text" : "password"}
                 value={remotePassword}
                 onChange={(e) => {
                   const pw = e.target.value;
-                  setRemotePwLocal(pw);       // local input
-                  setRemotePwGlobal(pw);      // memory cache for Runs
+                  setRemotePwLocal(pw); // local input
+                  setRemotePwGlobal(pw); // memory cache for Runs
                 }}
                 autoComplete="new-password"
               />
-              <button type="button" onClick={() => setShowPw(s => !s)}>
+              <button type="button" onClick={() => setShowPw((s) => !s)}>
                 {showPw ? "Hide" : "Show"}
               </button>
             </div>
-            <small style={{ opacity: 0.7 }}>
-              Password is kept in memory only (cleared on app exit).
-            </small>
+            <small className="settings-hint">Password is kept in memory only (cleared on app exit).</small>
           </label>
         )}
-
-        <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
-          <button onClick={testRemote}>Log in</button>
-          <span style={{ opacity: 0.8 }}>{status}</span>
-        </div>
       </section>
     </div>
   );

--- a/frontend/src/components/__tests__/Runs.remote.test.ts
+++ b/frontend/src/components/__tests__/Runs.remote.test.ts
@@ -7,6 +7,7 @@ import {
   sessionCacheKey,
   sessionCacheKeyForScope,
   renameWindowsCacheEntry,
+  buildSendKeysControlCommand,
   type HostProfile,
   type Mode,
   type TmuxWindow,
@@ -126,5 +127,25 @@ describe("cache helpers", () => {
     // renaming a non-existent entry is a no-op
     renameWindowsCacheEntry(cache, scope, "missing", "noop");
     expect(cache.size).toBe(1);
+  });
+});
+
+describe("buildSendKeysControlCommand", () => {
+  it("includes literal flag and enter when requested", () => {
+    expect(buildSendKeysControlCommand("arc:0", "ls -la", true)).toBe(
+      "send-keys -t arc:0 -l 'ls -la' Enter",
+    );
+  });
+
+  it("omits enter when not requested", () => {
+    expect(buildSendKeysControlCommand("local", "whoami", false)).toBe(
+      "send-keys -t local -l whoami",
+    );
+  });
+
+  it("escapes quotes and whitespace in the literal payload", () => {
+    expect(buildSendKeysControlCommand("pane @1", "echo 'hi'", true)).toBe(
+      "send-keys -t 'pane @1' -l 'echo '\"'\"'hi'\"'\"'' Enter",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- send tmux key sequences with the literal flag and optional enter in a single command for both local and remote sessions to reduce terminal latency
- refresh the remote loading indicator with a continuously animated strip and expose a helper for control-mode send-keys logic
- tighten the Settings view layout with smaller controls, grid-based remote fields, and supporting styles for easier access to the login controls

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e3cec0889c8322919266a230b2e002