### PR TITLE
Fix remote send-keys enter command and steady runs status layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -407,6 +407,33 @@ main {
   letter-spacing: 0.01em;
 }
 
+.runs-page__status {
+  display: grid;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.runs-page__status-remote,
+.runs-page__status-message {
+  min-height: 1.4em;
+  font-size: 12.5px;
+  color: var(--muted);
+  transition: color 0.18s ease, opacity 0.18s ease;
+}
+
+.runs-page__status-remote {
+  opacity: 0.85;
+}
+
+.runs-page__status-message {
+  opacity: 0.75;
+}
+
+.runs-page__status-message--active {
+  color: var(--text);
+  opacity: 0.95;
+}
+
 .pane {
   flex: 1 1 auto;
   min-height: 260px;

--- a/frontend/src/components/__tests__/Runs.remote.test.ts
+++ b/frontend/src/components/__tests__/Runs.remote.test.ts
@@ -131,21 +131,30 @@ describe("cache helpers", () => {
 });
 
 describe("buildSendKeysControlCommand", () => {
-  it("includes literal flag and enter when requested", () => {
-    expect(buildSendKeysControlCommand("arc:0", "ls -la", true)).toBe(
-      "send-keys -t arc:0 -l 'ls -la' Enter",
-    );
+  it("emits separate literal and enter commands when requested", () => {
+    expect(buildSendKeysControlCommand("arc:0", "ls -la", true)).toEqual([
+      "send-keys -t arc:0 -l 'ls -la'",
+      "send-keys -t arc:0 Enter",
+    ]);
   });
 
-  it("omits enter when not requested", () => {
-    expect(buildSendKeysControlCommand("local", "whoami", false)).toBe(
+  it("omits the enter command when not requested", () => {
+    expect(buildSendKeysControlCommand("local", "whoami", false)).toEqual([
       "send-keys -t local -l whoami",
-    );
+    ]);
   });
 
   it("escapes quotes and whitespace in the literal payload", () => {
-    expect(buildSendKeysControlCommand("pane @1", "echo 'hi'", true)).toBe(
-      "send-keys -t 'pane @1' -l 'echo '\"'\"'hi'\"'\"'' Enter",
-    );
+    expect(buildSendKeysControlCommand("pane @1", "echo 'hi'", true)).toEqual([
+      "send-keys -t 'pane @1' -l 'echo '\"'\"'hi'\"'\"''",
+      "send-keys -t 'pane @1' Enter",
+    ]);
+  });
+
+  it("preserves embedded newlines in the literal payload", () => {
+    expect(buildSendKeysControlCommand("arc:1", "printf 'a\\n'", true)).toEqual([
+      "send-keys -t arc:1 -l 'printf '\"'\"'a\\n'\"'\"''",
+      "send-keys -t arc:1 Enter",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- send remote control-mode key sequences without embedding the literal word "Enter"
- stabilize the runs view header with a dedicated status area and updated styles
- extend the send-keys helper tests to cover the revised command sequencing

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e3d47fb31c8322a0e21f8764a3d906