### PR TITLE
Fix remote send-key newline and stabilize remote tab UI

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -316,6 +316,46 @@ main {
   transition: all 0.18s ease;
 }
 
+.tab__label {
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.2;
+}
+
+.tab__spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  border: 2px solid rgba(123, 156, 255, 0.35);
+  border-top-color: rgba(123, 156, 255, 0.9);
+  opacity: 0;
+  transform: scale(0.75);
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  flex-shrink: 0;
+}
+
+.tab__spinner--visible {
+  opacity: 1;
+  transform: scale(1);
+  animation: tab-spinner 0.9s linear infinite;
+}
+
+@keyframes tab-spinner {
+  from {
+    transform: scale(1) rotate(0deg);
+  }
+  to {
+    transform: scale(1) rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tab__spinner--visible {
+    animation-duration: 1.6s;
+  }
+}
+
 .tab:hover {
   color: var(--text);
   border-color: rgba(123, 156, 255, 0.35);

--- a/frontend/src/components/Runs.tsx
+++ b/frontend/src/components/Runs.tsx
@@ -85,6 +85,12 @@ export const renameWindowsCacheEntry = (
   cache.set(sessionCacheKeyForScope(scope, newSession), existing);
 };
 
+export const remoteButtonAriaLabel = (remoteLoading: boolean, sessionLoading: boolean): string => {
+  if (remoteLoading) return "Remote (connecting…)";
+  if (sessionLoading) return "Remote (loading…)";
+  return "Remote";
+};
+
 const REMOTE_TIMEOUT_MS = 12000;
 
 const escapeArg = (value: string) => {
@@ -166,6 +172,8 @@ export default function Runs() {
     mode.kind === "remote"
       ? `${mode.profile.user}@${mode.profile.host}:${mode.profile.port ?? 22}`
       : "";
+  const remoteAriaLabel = remoteButtonAriaLabel(remoteLoading, sessionLoading);
+  const remoteSpinnerVisible = remoteLoading || sessionLoading;
   const paneDivRef = useRef<HTMLDivElement | null>(null);
   const timerRef = useRef<number | null>(null);
   const activeWinRef = useRef<number | null>(null);
@@ -1356,12 +1364,13 @@ async function onSendKeys(keys: string, enter = true) {
             className={`tab tab--condensed ${mode.kind === "remote" ? "tab--active" : ""}`}
             onClick={() => remoteCfg && switchToRemote(remoteCfg)}
             disabled={!remoteCfg || remoteLoading || sessionLoading}
+            aria-label={remoteAriaLabel}
           >
-            {remoteLoading
-              ? "Remote (connecting…)"
-              : sessionLoading
-                ? "Remote (loading…)"
-                : "Remote"}
+            <span className="tab__label">Remote</span>
+            <span
+              className={`tab__spinner${remoteSpinnerVisible ? " tab__spinner--visible" : ""}`}
+              aria-hidden="true"
+            />
           </button>
           {mode.kind === "remote" && controlDisconnected && controlRef.current && (
             <button

--- a/frontend/src/components/__tests__/Runs.remote.test.ts
+++ b/frontend/src/components/__tests__/Runs.remote.test.ts
@@ -8,6 +8,7 @@ import {
   sessionCacheKeyForScope,
   renameWindowsCacheEntry,
   buildSendKeysControlCommand,
+  remoteButtonAriaLabel,
   type HostProfile,
   type Mode,
   type TmuxWindow,
@@ -156,5 +157,20 @@ describe("buildSendKeysControlCommand", () => {
       "send-keys -t arc:1 -l 'printf '\"'\"'a\\n'\"'\"''",
       "send-keys -t arc:1 Enter",
     ]);
+  });
+});
+
+describe("remoteButtonAriaLabel", () => {
+  it("prioritizes the remote loading state", () => {
+    expect(remoteButtonAriaLabel(true, true)).toBe("Remote (connecting…)");
+    expect(remoteButtonAriaLabel(true, false)).toBe("Remote (connecting…)");
+  });
+
+  it("falls back to the session loading label", () => {
+    expect(remoteButtonAriaLabel(false, true)).toBe("Remote (loading…)");
+  });
+
+  it("returns the base label when idle", () => {
+    expect(remoteButtonAriaLabel(false, false)).toBe("Remote");
   });
 });


### PR DESCRIPTION
## Summary
- split literal and Enter tmux commands for local and remote send-keys and cover them with unit tests
- expose a helper for remote tab aria labeling and add spinner-based UI to avoid layout shifts
- style the remote tab spinner to preserve button sizing while showing connection progress

## Testing
- npm test -- --run
- cargo test *(fails: system library glib-2.0 unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d7277f7c8322b8c0b9fe8c6e2d20